### PR TITLE
Add new syscall get_taskinfo

### DIFF
--- a/os/build.rs
+++ b/os/build.rs
@@ -53,9 +53,13 @@ _num_apps:
         )?;
 
         for i in 0..total_apps {
-            writeln!(dst, r#"    .quad app_{i}_start"#)?;
+            writeln!(
+                dst,
+                r#"    .quad app_{i}_name
+    .quad app_{i}_start
+    .quad app_{i}_end"#
+            )?;
         }
-        writeln!(dst, r#"    .quad app_{}_end"#, total_apps - 1)?;
 
         // Write the per-app part
         for i in 0..total_apps {
@@ -63,11 +67,15 @@ _num_apps:
                 dst,
                 r#"
     .section .data
+    .global app_{i}_name
     .global app_{i}_start
     .global app_{i}_end
+app_{i}_name:
+    .ascii "{app_name_bytes}"
 app_{i}_start:
     .incbin "{bin_dir}/{app_name}.bin"
 app_{i}_end:"#,
+                app_name_bytes = app_names[i],
                 bin_dir = Self::BIN_DIR,
                 app_name = app_names[i]
             )?;

--- a/os/src/batch.rs
+++ b/os/src/batch.rs
@@ -44,6 +44,11 @@ impl AppManager {
     /// The agreed-upon address where the running app should be installed.
     const APP_MEM_ADDR: *mut u8 = 0x8040_0000 as *mut u8;
     const APP_MAX_SIZE: usize = 0x2_0000;
+    /// The number of meta information items kept for each app.
+    ///
+    /// Currently, we keep app_name, app_start, and app_end for each app under
+    /// the _num_apps in the generated link_apps.S.
+    const APP_META_SIZE: usize = 3;
 
     /// `get_info_base_ptr` returns a pointer to the _num_apps, which is
     /// defined in the generated link_app.S.
@@ -65,7 +70,11 @@ impl AppManager {
         if app_index >= Self::get_total_apps() {
             return 0;
         }
-        unsafe { Self::get_info_base_ptr().add(app_index + 1).read() as usize }
+        unsafe {
+            Self::get_info_base_ptr()
+                .add(app_index * AppManager::APP_META_SIZE + 2)
+                .read() as usize
+        }
     }
 
     /// `get_app_data_end` returns the end address (exclusive) of the app
@@ -74,7 +83,11 @@ impl AppManager {
         if app_index >= Self::get_total_apps() {
             return 0;
         }
-        unsafe { Self::get_info_base_ptr().add(app_index + 2).read() as usize }
+        unsafe {
+            Self::get_info_base_ptr()
+                .add(app_index * AppManager::APP_META_SIZE + 3)
+                .read() as usize
+        }
     }
 
     pub fn run_next_app() -> ! {

--- a/os/src/batch.rs
+++ b/os/src/batch.rs
@@ -65,7 +65,8 @@ impl AppManager {
     }
 
     /// `get_app_name` returns the name of the app, or an empty string if the
-    ///  app_index is invalid. Only ASCII characters are supported.
+    /// app index is invalid or the app name is invalid. Only ASCII characters
+    /// are supported.
     pub fn get_app_name<'a>(app_index: usize) -> &'a str {
         if app_index >= Self::get_total_apps() {
             return "";
@@ -77,7 +78,7 @@ impl AppManager {
         };
         let app_name_len = Self::get_app_data_start(app_index) - (app_name_ptr as usize);
         let slice = unsafe { slice::from_raw_parts(app_name_ptr, app_name_len) };
-        core::str::from_utf8(slice).unwrap()
+        core::str::from_utf8(slice).unwrap_or("")
     }
 
     /// `get_app_data_start` returns the starting address of the app data

--- a/os/src/batch.rs
+++ b/os/src/batch.rs
@@ -106,6 +106,13 @@ impl AppManager {
         }
     }
 
+    /// `get_curr_app_index` returns the index of the currently running app.
+    /// Clients should ensure that an app is indeed running; otherswis, the
+    /// returned result is invalid.
+    pub fn get_curr_app_index() -> usize {
+        NEXT_APP_INDEX.load(Ordering::Relaxed) - 1
+    }
+
     pub fn run_next_app() -> ! {
         let app_index = NEXT_APP_INDEX.fetch_add(1, Ordering::Relaxed);
         if app_index >= Self::get_total_apps() {

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -96,6 +96,10 @@ fn log_apps_layout() {
         let app_start = AppManager::get_app_data_start(i);
         let app_end = AppManager::get_app_data_end(i);
         let size = app_end - app_start;
-        debug!("app_{} [{:#x}, {:#x}) size={}", i, app_start, app_end, size);
+        let app_name = AppManager::get_app_name(i);
+        debug!(
+            "app_{} [{:#x}, {:#x}) size={}, name={}",
+            i, app_start, app_end, size, app_name
+        );
     }
 }

--- a/os/src/syscall.rs
+++ b/os/src/syscall.rs
@@ -6,11 +6,13 @@ const SYSCALL_WRITE: usize = 64;
 const FD_STD: usize = 1;
 
 const SYSCALL_EXIT: usize = 93;
+const SYSCALL_TASK_INFO: usize = (1 << 63) | 1;
 
 pub fn syscall_handler(syscall_id: usize, args: [usize; 3]) -> isize {
     match syscall_id {
         SYSCALL_WRITE => sys_write(args[0], args[1] as *const u8, args[2]),
         SYSCALL_EXIT => sys_exit(args[0] as isize),
+        SYSCALL_TASK_INFO => sys_task_info(),
         _ => panic!("Unknown syscall, id={syscall_id}, args={args:?}"),
     }
 }
@@ -29,4 +31,12 @@ fn sys_write(fd: usize, buf: *const u8, count: usize) -> isize {
 fn sys_exit(exit_code: isize) -> ! {
     println!("[KERNEL] Application exited with code {}", exit_code);
     AppManager::run_next_app()
+}
+
+fn sys_task_info() -> isize {
+    let app_index = AppManager::get_curr_app_index();
+    let app_name = AppManager::get_app_name(app_index);
+
+    println!("[KERNEL] Running Task {{ index: {}, name: {} }}", app_index, app_name);
+    0
 }

--- a/user/src/bin/05_trytaskinfo.rs
+++ b/user/src/bin/05_trytaskinfo.rs
@@ -1,0 +1,14 @@
+#![no_std]
+#![no_main]
+
+extern crate user_lib;
+
+use user_lib::{get_task_info, println};
+
+#[unsafe(no_mangle)]
+fn main() -> i32 {
+    println!("Try to get the information of current running app");
+    get_task_info();
+    println!("Kernel should have display the information of current running app");
+    0
+}

--- a/user/src/lib.rs
+++ b/user/src/lib.rs
@@ -4,7 +4,7 @@ pub mod console;
 mod lang_items;
 mod syscall;
 
-use syscall::{sys_exit, sys_write};
+use syscall::{sys_exit, sys_task_info, sys_write};
 
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.entry")]
@@ -34,4 +34,8 @@ pub fn write(fd: usize, buf: &[u8]) -> isize {
 
 pub fn exit(exit_code: i32) -> isize {
     sys_exit(exit_code)
+}
+
+pub fn get_task_info() -> isize {
+    sys_task_info()
 }

--- a/user/src/syscall.rs
+++ b/user/src/syscall.rs
@@ -2,6 +2,7 @@ use core::arch::asm;
 
 const SYSCALL_WRITE: usize = 64;
 const SYSCALL_EXIT: usize = 93;
+const SYSCALL_TASK_INFO: usize = (1 << 63) | 1;
 
 fn syscall(id: usize, args: [usize; 3]) -> isize {
     let mut result: isize;
@@ -23,4 +24,8 @@ pub fn sys_write(fd: usize, buffer: &[u8]) -> isize {
 
 pub fn sys_exit(xstate: i32) -> isize {
     syscall(SYSCALL_EXIT, [xstate as usize, 0, 0])
+}
+
+pub fn sys_task_info() -> isize {
+    syscall(SYSCALL_TASK_INFO, [0, 0, 0])
 }


### PR DESCRIPTION
This pull request adds a new syscall, `get_taskinfo`, which allows applications in user mode to query the currently running task.

The main idea of the implementation is to include the application names in the generated `link_apps.S` and to provide methods to access them. There are limitations on the application name: only ASCII characters are supported.