### PR TITLE
os::syscall: Add memory checks to sys_write

### DIFF
--- a/os/build.rs
+++ b/os/build.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
 
@@ -25,6 +26,8 @@ impl UserApp {
     }
 
     fn get_app_names() -> Vec<String> {
+        let include_test = env::var("TEST").is_ok_and(|s| s == "1");
+
         fs::read_dir(Self::SRC_DIR)
             .unwrap()
             .map(|entry| entry.unwrap().file_name().into_string().unwrap())
@@ -33,6 +36,13 @@ impl UserApp {
                     .strip_suffix(Self::SRC_EXTENSION)
                     .unwrap()
                     .to_string()
+            })
+            .filter(|name| {
+                if include_test {
+                    true
+                } else {
+                    !name.starts_with("test_")
+                }
             })
             .collect::<Vec<_>>()
     }

--- a/os/src/batch.rs
+++ b/os/src/batch.rs
@@ -30,7 +30,7 @@ impl KernelStack {
 struct UserStack([u8; USER_STACK_SIZE]);
 
 impl UserStack {
-    pub fn get_init_top() -> usize {
+    fn get_init_top() -> usize {
         unsafe {
             let ptr = &raw const USER_STACK.0 as *const u8;
             ptr.add(USER_STACK_SIZE) as usize

--- a/os/src/syscall.rs
+++ b/os/src/syscall.rs
@@ -26,6 +26,13 @@ fn sys_write(fd: usize, buf: *const u8, count: usize) -> isize {
         return -1;
     }
 
+    if !AppManager::can_app_read_addr(buf.addr())
+        || !AppManager::can_app_read_addr(buf.addr() + count - 1)
+    {
+        println!("[KERNEL] User attempts to read an memory address without permission");
+        return -1;
+    }
+
     let buf = unsafe { slice::from_raw_parts(buf, count) };
     let str = str::from_utf8(buf).unwrap();
     print!("{str}");

--- a/os/src/syscall.rs
+++ b/os/src/syscall.rs
@@ -29,7 +29,7 @@ fn sys_write(fd: usize, buf: *const u8, count: usize) -> isize {
     if !AppManager::can_app_read_addr(buf.addr())
         || !AppManager::can_app_read_addr(buf.addr() + count - 1)
     {
-        println!("[KERNEL] User attempts to read an memory address without permission");
+        println!("[KERNEL] User attempts to read a memory address without permission");
         return -1;
     }
 

--- a/user/src/bin/test_safewrite.rs
+++ b/user/src/bin/test_safewrite.rs
@@ -1,0 +1,76 @@
+#![no_std]
+#![no_main]
+
+extern crate user_lib;
+
+use core::arch::asm;
+
+use core::slice;
+use user_lib::{println, write};
+
+/// Expect:
+/// string from data section
+/// strinstring from stack section
+/// strin
+/// Test write OK!
+
+const STACK_SIZE: usize = 0x2000;
+const STACK_ALIGN: usize = 0x1000;
+
+const STDOUT: usize = 1;
+const DATA_STRING: &str = "string from data section\n";
+
+unsafe fn r_sp() -> usize {
+    let mut sp: usize;
+    unsafe { asm!("mv {}, sp", out(reg) sp) };
+    sp
+}
+
+unsafe fn stack_range() -> (usize, usize) {
+    let sp = unsafe { r_sp() };
+    // Require the sp to be in the top half of the user stack, which should
+    // be fine for the current case.
+    let top = (sp + STACK_ALIGN - 1) & (!(STACK_ALIGN - 1));
+    (top - STACK_SIZE, top)
+}
+
+#[unsafe(no_mangle)]
+pub fn main() -> i32 {
+    assert_eq!(
+        write(STDOUT, unsafe {
+            #[allow(clippy::zero_ptr)]
+            slice::from_raw_parts(0x0 as *const _, 10)
+        }),
+        -1
+    );
+    let (bottom, top) = unsafe { stack_range() };
+    assert_eq!(
+        write(STDOUT, unsafe {
+            slice::from_raw_parts((top - 5) as *const _, 10)
+        }),
+        -1
+    );
+    assert_eq!(
+        write(STDOUT, unsafe {
+            slice::from_raw_parts((bottom - 5) as *const _, 10)
+        }),
+        -1
+    );
+
+    assert_eq!(write(1234, DATA_STRING.as_bytes()), -1);
+
+    assert_eq!(
+        write(STDOUT, DATA_STRING.as_bytes()),
+        DATA_STRING.len() as isize
+    );
+    assert_eq!(write(STDOUT, &DATA_STRING.as_bytes()[..5]), 5);
+
+    let stack_string = "string from stack section\n";
+    assert_eq!(
+        write(STDOUT, stack_string.as_bytes()),
+        stack_string.len() as isize
+    );
+    assert_eq!(write(STDOUT, &stack_string.as_bytes()[..5]), 5);
+    println!("\nTest write OK!");
+    0
+}


### PR DESCRIPTION
The existing implementation of `sys_write` allows a user app to read arbitrary memory addresses, which is definitely problematic. This pull request adds memory checks to `sys_write`, limiting user apps to reading their own memory ranges and stacks. It is important to note that this implementation is specific to the current batch OS.